### PR TITLE
[fix] constraint can not use minMessage and maxMessage when the min a…

### DIFF
--- a/web/src/Form/FoodFormType.php
+++ b/web/src/Form/FoodFormType.php
@@ -29,8 +29,6 @@ class FoodFormType extends AbstractType
                     new Range([
                         'min' => 0,
                         'max' => 100,
-                        'minMessage' => 'La quantité doit être au moins {{ limit }}.',
-                        'maxMessage' => 'La quantité ne peut pas être supérieure à {{ limit }}.',
                         'notInRangeMessage' => 'La quantité doit être au dessus 0 et en dessous de 100'
                     ]),
                 ],


### PR DESCRIPTION
…nd max options are both set. Use notInRangeMessage instead.